### PR TITLE
Add missing java packaging

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,15 +57,6 @@ jobs:
 
       - run: python3 -m unittest test.unit
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Run Java tests with Maven
-        run: mvn -f lib_java/pom.xml test
-
       - run: pwd
       - run: ls -R
 

--- a/dates_calc.opam
+++ b/dates_calc.opam
@@ -22,6 +22,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "alcotest" {with-test & >= "1.0.0"}
   "qcheck" {with-test & >= "0.10"}
+  "conf-openjdk" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/lib_java/dune
+++ b/lib_java/dune
@@ -1,0 +1,4 @@
+(install
+ (section lib)
+ (files
+  (glob_files (src/main/java/dates_calc/*.java with_prefix java))))

--- a/lib_java/src/main/java/dates_calc/AmbiguousComputationException.java
+++ b/lib_java/src/main/java/dates_calc/AmbiguousComputationException.java
@@ -1,4 +1,4 @@
-package catala.dates_calc;
+package dates_calc;
 
 public class AmbiguousComputationException extends RuntimeException {
     public AmbiguousComputationException(String message) {

--- a/lib_java/src/main/java/dates_calc/Date.java
+++ b/lib_java/src/main/java/dates_calc/Date.java
@@ -1,4 +1,4 @@
-package catala.dates_calc;
+package dates_calc;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/lib_java/src/main/java/dates_calc/Period.java
+++ b/lib_java/src/main/java/dates_calc/Period.java
@@ -1,4 +1,4 @@
-package catala.dates_calc;
+package dates_calc;
 
 import java.util.Objects;
 import java.util.regex.Matcher;

--- a/lib_java/src/test/java/dates_calc/DatesCalcTest.java
+++ b/lib_java/src/test/java/dates_calc/DatesCalcTest.java
@@ -1,4 +1,4 @@
-package catala.dates_calc;
+package dates_calc;
 
 import java.io.BufferedReader;
 import java.io.FileReader;

--- a/test/dune
+++ b/test/dune
@@ -26,3 +26,8 @@
  (alias runtest)
  (action
   (run ./unit.c.exe)))
+
+(rule
+ (alias runtest)
+ (deps (source_tree ../lib_java))
+ (action (chdir ../lib_java (run mvn test))))


### PR DESCRIPTION
This PR fixes the missing installation of the Java files. We (@AltGr & myself) figured that copying over the Java files as is would be better than to depends on Java. Hence, it's the user's responsibility to compile the java files as needed.